### PR TITLE
Added route /event/:id/dashboard

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
     end
   end
 
+  get '/event/:id/dashboard', to: 'events#dashboard'
   get '/reviews', to: 'reviews#create'
 end


### PR DESCRIPTION
events#dashboard is the page that shows all the info/details of an event, including all the songs the events have and the info of the songs.
It also contains the links to edit event info(venue, etc.), add songs to the event and edit the songs of the event

In previous exercises(for example Airbnb), this page is actually flat/:id, but we used event/:id for another purpose, so I created a new route for that.
